### PR TITLE
Slash ext

### DIFF
--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -12,18 +12,16 @@ class CrajySlashCommands(commands.Cog):
     def cog_unload(self):
         self.bot.slash.remove_cog_commands(self)
         
-    @cog_ext.cog_subcommand(base="damn", 
+    @cog_ext.cog_slash(name="wat", 
+                       description="Use a wat command",
+                       guild_ids=[298871492924669954], 
+                       options=[utils.manage_commands.create_option(
                             name="use", 
-                            description="Use a wat command",
-                            base_desc=":flushed:",
-                            guild_ids=[298871492924669954], 
-                            options=[utils.manage_commands.create_option(
-                                name="name", 
-                                description="Which tag to bring.",
-                                option_type=3,
-                                required=True)])
-    async def slash_wat(self, ctx: SlashContext, name: str):
-        existing = await self.bot.stupid_collection.find_one({"key": name})
+                            description="Which tag to bring.",
+                            option_type=3,
+                            required=True)])
+    async def slash_wat(self, ctx: SlashContext, use: str):
+        existing = await self.bot.stupid_collection.find_one({"key": use})
         await ctx.send(content=existing["output"])
 
 def setup(bot):

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -7,10 +7,10 @@ class CrajySlashCommands(commands.Cog):
             bot.slash = SlashCommand(bot, auto_register=True, override_type=True)
 
         self.bot = bot
-        self.bot.slash.get_cog_commands(self
+        self.bot.slash.get_cog_commands(self)
         
     @cog_ext.cog_subcommand(base="wat", name="use")
-    async def group_say(self, ctx: SlashContext, text: str):
+    async def slash_wat(self, ctx: SlashContext, text: str):
         existing = await self.bot.stupid_collection.find_one({"key": text})
         await ctx.send(content=existing["output"])
 

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -20,7 +20,7 @@ class CrajySlashCommands(commands.Cog):
                             options=[utils.manage_commands.create_option(
                                 name="name", 
                                 description="Which tag to bring.",
-                                option_type="STRING",
+                                option_type=3,
                                 required=True)])
     async def slash_wat(self, ctx: SlashContext, name: str):
         existing = await self.bot.stupid_collection.find_one({"key": name})

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -1,0 +1,18 @@
+from discord.ext import commands
+from discord_slash import cog_ext, SlashCommand, SlashContext
+
+class CrajySlashCommands(commands.Cog):
+    def __init__(self, bot):
+        if not hasattr(bot, "slash"):
+            bot.slash = SlashCommand(bot, auto_register=True, override_type=True)
+
+        self.bot = bot
+        self.bot.slash.get_cog_commands(self
+        
+    @cog_ext.cog_subcommand(base="wat", name="use")
+    async def group_say(self, ctx: SlashContext, text: str):
+        existing = await self.bot.stupid_collection.find_one({"key": text})
+        await ctx.send(content=existing["output"])
+
+def setup(bot):
+    bot.add_cog(CrajySlashCommands(bot))

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -12,7 +12,7 @@ class CrajySlashCommands(commands.Cog):
     def cog_unload(self):
         self.bot.slash.remove_cog_commands(self)
         
-    @cog_ext.cog_subcommand(base="wat", name="use", guild_ids=[298871492924669954])
+    @cog_ext.cog_subcommand(base="damn", name="use", guild_ids=[298871492924669954])
     async def slash_wat(self, ctx: SlashContext, text: str):
         existing = await self.bot.stupid_collection.find_one({"key": text})
         await ctx.send(content=existing["output"])

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -9,6 +9,9 @@ class CrajySlashCommands(commands.Cog):
         self.bot = bot
         self.bot.slash.get_cog_commands(self)
         
+    def cog_unload(self):
+        self.bot.slash.remove_cog_commands(self)
+        
     @cog_ext.cog_subcommand(base="wat", name="use", guild_ids=[298871492924669954])
     async def slash_wat(self, ctx: SlashContext, text: str):
         existing = await self.bot.stupid_collection.find_one({"key": text})

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -1,5 +1,5 @@
 from discord.ext import commands
-from discord_slash import cog_ext, SlashCommand, SlashContext
+from discord_slash import cog_ext, SlashCommand, SlashContext, utils
 
 class CrajySlashCommands(commands.Cog):
     def __init__(self, bot):
@@ -12,9 +12,18 @@ class CrajySlashCommands(commands.Cog):
     def cog_unload(self):
         self.bot.slash.remove_cog_commands(self)
         
-    @cog_ext.cog_subcommand(base="damn", name="use", guild_ids=[298871492924669954])
-    async def slash_wat(self, ctx: SlashContext, text: str):
-        existing = await self.bot.stupid_collection.find_one({"key": text})
+    @cog_ext.cog_subcommand(base="damn", 
+                            name="use", 
+                            description="Use a wat command",
+                            base_desc=":flushed:",
+                            guild_ids=[298871492924669954], 
+                            options=[utils.manage_commands.create_option(
+                                name="name", 
+                                description="Which tag to bring.",
+                                option_type="STRING",
+                                required=True)])
+    async def slash_wat(self, ctx: SlashContext, name: str):
+        existing = await self.bot.stupid_collection.find_one({"key": name})
         await ctx.send(content=existing["output"])
 
 def setup(bot):

--- a/cogs/slash.py
+++ b/cogs/slash.py
@@ -9,7 +9,7 @@ class CrajySlashCommands(commands.Cog):
         self.bot = bot
         self.bot.slash.get_cog_commands(self)
         
-    @cog_ext.cog_subcommand(base="wat", name="use")
+    @cog_ext.cog_subcommand(base="wat", name="use", guild_ids=[298871492924669954])
     async def slash_wat(self, ctx: SlashContext, text: str):
         existing = await self.bot.stupid_collection.find_one({"key": text})
         await ctx.send(content=existing["output"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ yarl==1.4.2
 matplotlib==3.3.3
 numpy==1.19.4
 jishaku==1.19.0
+discord-py-slash-command-1.0.8.5


### PR DESCRIPTION
Made .wat into a slash command that shares the same database; this doesn't need the use of a webserver to interact with incoming webhook type interactions from the discord API, and instead uses the wrapper discord-py-slash-commands ext library.